### PR TITLE
Paused streams and watchdog improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rxkit",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rxkit",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxkit",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A lightweight, no dependency component kit for reactive programming",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/watchdog.ts
+++ b/src/components/watchdog.ts
@@ -32,6 +32,9 @@ export class Watchdog<T> extends Feeder<T> {
 		stream.resume = () => {
 			arm();
 		};
+		stream.pause = () => {
+			clearTimeout(t);
+		};
 
 		arm();
 		return stream;

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,11 @@ export class PushStream {
 	resume?: () => void = undefined;
 
 	/**
+	 * If defined, this method will be called everytime a PushStream enabled state is changed from true to false
+	 */
+	pause?: () => void = undefined;
+
+	/**
 	 * An optional Feedable endpoint which will trigger the stream when it is fed to.
 	 */
 	trigger?: ConsumeFunction<any>;
@@ -91,9 +96,13 @@ export class PushStream {
 	}
 
 	set enabled(b: boolean) {
-		if (!this._enabled && b && this.resume) {
+		if (!this._enabled && b && this.resume !== undefined) {
 			this._enabled = b;
 			this.resume();
+		}
+		else if (this._enabled && !b && this.pause !== undefined) {
+			this._enabled = b;
+			this.pause();
 		}
 		else {
 			this._enabled = b;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -156,6 +156,22 @@ describe('PushStream', () => {
 		p.enabled = true;
 		expect(fn).toBeCalledTimes(1);
 	});
+	it('Pause', () => {
+		const fn = jest.fn();
+		let p = new PushStream();
+		p.pause = () => {
+			fn();
+		};
+		expect(p.enabled).toBe(true);
+		p.enabled = true;
+		expect(fn).toBeCalledTimes(0);
+		p.enabled = false;
+		expect(fn).toBeCalledTimes(1);
+		p.enabled = false;
+		expect(fn).toBeCalledTimes(1);
+		p.enabled = true;
+		expect(fn).toBeCalledTimes(1);
+	});
 	it('Trigger', () => {
 		let p = new PushStream();
 		let f = new SimpleFeeder(1);

--- a/tests/watchdog.test.ts
+++ b/tests/watchdog.test.ts
@@ -1,10 +1,17 @@
-import { setTimeout } from "timers/promises";
 import { ConsumeFunction, ImmediateFeeder, Watchdog } from "../src";
 
+function mockTimeout(ms: number): Promise<void> {
+	const p = new Promise<void>((r) => {
+		setTimeout(() => r(), ms);
+	});
+	jest.advanceTimersByTime(ms);
+	return p;
+}
 
 describe('Watchdog', () => {
 
 	it('Feed', () => {
+		jest.useFakeTimers();
 		let fn = jest.fn();
 		let c: ConsumeFunction<number> = (n) => {
 			fn(n);
@@ -15,25 +22,27 @@ describe('Watchdog', () => {
 		// Must not be called yet
 		expect(fn).toBeCalledTimes(0);
 
-		return setTimeout(10)
+		return mockTimeout(10)
 			.then(() => {
 				expect(fn).toBeCalledTimes(0);
 			})
-			.then(() => setTimeout(50))
+			.then(() => mockTimeout(50))
 			.then(() => {
 				expect(fn).toBeCalledTimes(1);
 				expect(fn).toHaveBeenNthCalledWith(1, 13);
 				expect(stream.enabled).toBe(false);
 			})
-			.then(() => setTimeout(55))
+			.then(() => mockTimeout(55))
 			.then(() => {
 				//Must not be called again
 				expect(fn).toBeCalledTimes(1);
 				expect(stream.enabled).toBe(false);
+				jest.useRealTimers();
 			});
 	});
 
 	it('Reset trigger', () => {
+		jest.useFakeTimers();
 		let fn = jest.fn();
 		let c: ConsumeFunction<number> = (n) => {
 			fn(n);
@@ -45,19 +54,19 @@ describe('Watchdog', () => {
 		// Must not be called yet
 		expect(fn).toBeCalledTimes(0);
 
-		return setTimeout(25)
+		return mockTimeout(25)
 			.then(() => {
 				expect(fn).toBeCalledTimes(0);
 				// Reset the watchdog
 				new ImmediateFeeder(0).triggers(stream);
 			})
-			.then(() => setTimeout(40))
+			.then(() => mockTimeout(40))
 			.then(() => {
 				// Must not be called yet, because the watchdog was reset and needs 50ms again
 				expect(fn).toBeCalledTimes(0);
 				expect(stream.enabled).toBe(true);
 			})
-			.then(() => setTimeout(15))
+			.then(() => mockTimeout(15))
 			.then(() => {
 				// Must be called now
 				expect(fn).toBeCalledTimes(1);
@@ -65,11 +74,12 @@ describe('Watchdog', () => {
 				// Re-enable the watchdog
 				stream.enabled = true;
 			})
-			.then(() => setTimeout(55))
+			.then(() => mockTimeout(55))
 			.then(() => {
 				// Must be called again
 				expect(fn).toBeCalledTimes(2);
 				expect(stream.enabled).toBe(false);
+				jest.useRealTimers();
 			});
 	});
 });


### PR DESCRIPTION
- Stream now have a pause() callback, which is called when a stream enabled state changes from true to false
- Watchdogs defuse on their streams pause
- Watchdog testing performance improvements with mocked timers